### PR TITLE
SIgnout of OP when done.

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -132,6 +132,15 @@ async function run(): Promise<void> {
         }
       }
     }
+
+    core.info('Signing out of op')
+    // Sign out of op
+    const signout = await execWithOutput(
+      'op',
+      ['signout', '--forget'],
+      {env}
+    )      
+
   } catch (error) {
     core.setFailed(error.message)
   }


### PR DESCRIPTION
Closes #29 

Calls a `op signout --forget` after the loop is done.

This is untested. Once we get a regular test user set up, we should make sure it runs. 