### PR TITLE
fix: Normalize 3+ word output names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
+## 2.1.0
+
+- Support for multi word names. Resolves [#54](https://github.com/RobotsAndPencils/1password-action/issues/54)
+
 ## 2.0.2
 
-- Fix CI linting step
+- Fix CI linting step Resolves [#58](https://github.com/RobotsAndPencils/1password-action/issues/58)
 
 ## 2.0.1
 
-- Fix execution environment for ubuntu >= 20.x
+- Fix execution environment for ubuntu >= 20.x. Resolves [#58](https://github.com/RobotsAndPencils/1password-action/issues/58)
 
 ## 2.0.0
 

--- a/__tests__/parsing.test.ts
+++ b/__tests__/parsing.test.ts
@@ -40,3 +40,19 @@ test('parses multiple unquoted, renamed items', async () => {
   expect(output[1].name).toBe('Test Password')
   expect(output[1].outputName).toBe('test_password')
 })
+
+test('parses single unquoted multi word item', async () => {
+  const output = parseItemRequestsInput('GitHub Action Test Vault > Test Login Four Words')
+  expect(output).toHaveLength(1)
+  expect(output[0].vault).toBe('GitHub Action Test Vault')
+  expect(output[0].name).toBe('Test Login Four Words')
+  expect(output[0].outputName).toBe('test_login_four_words')
+})
+
+test('parses single unquoted multi word item separated by periods', async () => {
+  const output = parseItemRequestsInput('GitHub Action Test Vault > Test.Login.Four.Words')
+  expect(output).toHaveLength(1)
+  expect(output[0].vault).toBe('GitHub Action Test Vault')
+  expect(output[0].name).toBe('Test.Login.Four.Words')
+  expect(output[0].outputName).toBe('test_login_four_words')
+})

--- a/src/parsing.ts
+++ b/src/parsing.ts
@@ -76,8 +76,8 @@ export function parseItemRequestsInput(itemInput: string): ItemRequest[] {
 
 function normalizeOutputName(dataKey: string): string {
   return dataKey
-    .replace(' ', '_')
-    .replace('.', '_')
+    .replace(/\s/g, '_')
+    .replace(/\./g, '_')
     .replace(/[^\p{L}\p{N}_-]/gu, '')
     .toLowerCase()
 }


### PR DESCRIPTION
#### What does this PR do?
<!-- Summary of changes here -->
- Fixes https://github.com/RobotsAndPencils/1password-action/issues/54
- With this change, the calls to `replace` now use a global regex, meaning it won't stop replacing after just the first character found.
- Since it changes output names I would consider this a breaking change

#### Did you update the Changelog?
- [ ] Changelog updated
